### PR TITLE
ci: enable trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Package
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Verify tag version
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Error: Tag version (v$TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version matched: $PKG_VERSION"
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm publish


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

This PR enables OIDC (OpenID Connect) publishing to npm using Trusted Publishing. I have already configured the OIDC publishing settings on the npm package side. Please see below image:

<img width="1233" height="495" alt="lqip" src="https://github.com/user-attachments/assets/efe35aa6-6592-4e16-a955-10e1b90f91f3" />


## Additional information

- Pushing a tag to GitHub will publish a package with the same version as the tag.
- For examples in other repositories, please refer to the following.
    - https://github.com/hexojs/hexo-generator-feed/actions/runs/21796718643/job/62885440009
    - https://github.com/hexojs/hexo-generator-feed/pull/257